### PR TITLE
Add Trigger Control Modules

### DIFF
--- a/addons/sequencer/CfgFunctions.hpp
+++ b/addons/sequencer/CfgFunctions.hpp
@@ -4,6 +4,7 @@ class CfgFunctions {
         #include "modules\HelloWorld\CfgFunctions.hpp"
         #include "modules\HelloWorld2\CfgFunctions.hpp"
         #include "modules\Delay\CfgFunctions.hpp"
+        #include "modules\AwaitTriggers\CfgFunctions.hpp"
 		#include "modules\Sequencer\CfgFunctions.hpp"
 
         class Global {

--- a/addons/sequencer/CfgFunctions.hpp
+++ b/addons/sequencer/CfgFunctions.hpp
@@ -5,6 +5,7 @@ class CfgFunctions {
         #include "modules\HelloWorld2\CfgFunctions.hpp"
         #include "modules\Delay\CfgFunctions.hpp"
         #include "modules\AwaitTriggers\CfgFunctions.hpp"
+        #include "modules\ActivateTriggers\CfgFunctions.hpp"
 		#include "modules\Sequencer\CfgFunctions.hpp"
 
         class Global {
@@ -14,6 +15,7 @@ class CfgFunctions {
             class Global_getSyncedSequenceModules {};
             class Global_getSyncedModules {};
             class Global_waitUntilTriggers {};
+            class Global_ActivateTriggers {};
             class Global_buildDirectedGraph {};
             class Global_invokeSequenceItem {};
         };

--- a/addons/sequencer/config.cpp
+++ b/addons/sequencer/config.cpp
@@ -5,6 +5,7 @@ class CfgPatches {
 			"ZT_Module_HelloWorld2",
 			"ZT_Module_Sequencer",
 			"ZT_Module_Delay",
+			"ZT_Module_AwaitTriggers",
 		};
     };
 };
@@ -32,6 +33,7 @@ class CfgVehicles {
 	#include "modules\HelloWorld2\CfgVehicles.hpp"
 	#include "modules\Sequencer\CfgVehicles.hpp"
 	#include "modules\Delay\CfgVehicles.hpp"
+	#include "modules\AwaitTriggers\CfgVehicles.hpp"
 };
 
 #include "CfgFunctions.hpp"

--- a/addons/sequencer/config.cpp
+++ b/addons/sequencer/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
 			"ZT_Module_Sequencer",
 			"ZT_Module_Delay",
 			"ZT_Module_AwaitTriggers",
+			"ZT_Module_ActivateTriggers",
 		};
     };
 };
@@ -34,6 +35,7 @@ class CfgVehicles {
 	#include "modules\Sequencer\CfgVehicles.hpp"
 	#include "modules\Delay\CfgVehicles.hpp"
 	#include "modules\AwaitTriggers\CfgVehicles.hpp"
+	#include "modules\ActivateTriggers\CfgVehicles.hpp"
 };
 
 #include "CfgFunctions.hpp"

--- a/addons/sequencer/functions/fn_Global_activateTriggers.sqf
+++ b/addons/sequencer/functions/fn_Global_activateTriggers.sqf
@@ -1,0 +1,10 @@
+params [
+	"_triggers"
+];
+
+{
+    if (_x isKindOf "EmptyDetector") then {
+        _x setTriggerStatements ["true", "thisTrigger", "thisTrigger"];
+        diag_log format ["[ZT Sequencer] Activated trigger: %1", _x];
+    };
+} forEach _triggers;

--- a/addons/sequencer/functions/fn_Global_activateTriggers.sqf
+++ b/addons/sequencer/functions/fn_Global_activateTriggers.sqf
@@ -4,7 +4,7 @@ params [
 
 {
     if (_x isKindOf "EmptyDetector") then {
-        _x setTriggerStatements ["true", "thisTrigger", "thisTrigger"];
+        _x setTriggerStatements ["true", (triggerStatements _x) select 1, (triggerStatements _x) select 2];
         diag_log format ["[ZT Sequencer] Activated trigger: %1", _x];
     };
 } forEach _triggers;

--- a/addons/sequencer/functions/fn_Global_waitUntilTriggers.sqf
+++ b/addons/sequencer/functions/fn_Global_waitUntilTriggers.sqf
@@ -1,9 +1,12 @@
 params [
-	"_triggers"
+	"_triggers",
+	"_cycleTime"
 ];
 
+if (isNil "_cycleTime") then {_cycleTime = 0.2};
+
 waitUntil {
-	sleep 0.2;
+	sleep _cycleTime;
 	_state = true;
 	{
 		_state = _state && (triggerActivated _x);

--- a/addons/sequencer/modules/ActivateTriggers/CfgFunctions.hpp
+++ b/addons/sequencer/modules/ActivateTriggers/CfgFunctions.hpp
@@ -1,4 +1,4 @@
 class ActivateTriggers {
 	file = "z\ZT\Sequencer\modules\ActivateTriggers\functions";
-	class ActivateTriggers {};
+	class activateTriggers {};
 };

--- a/addons/sequencer/modules/ActivateTriggers/CfgFunctions.hpp
+++ b/addons/sequencer/modules/ActivateTriggers/CfgFunctions.hpp
@@ -1,0 +1,4 @@
+class ActivateTriggers {
+	file = "z\ZT\Sequencer\modules\ActivateTriggers\functions";
+	class ActivateTriggers {};
+};

--- a/addons/sequencer/modules/ActivateTriggers/CfgVehicles.hpp
+++ b/addons/sequencer/modules/ActivateTriggers/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class ZT_Module_ActivateTriggers  : BaseSequenceModule {
 	displayName = "Activate Triggers";
 	scope = 2;
 	function = "";
-	ZT_executionFunction = "ZT_Sequencer_fnc_ActivateTriggers";
+	ZT_executionFunction = "ZT_Sequencer_fnc_activateTriggers";
 	functionPriority = 1;
 	isGlobal = 1;
 	isTriggerActivated = 1;

--- a/addons/sequencer/modules/ActivateTriggers/CfgVehicles.hpp
+++ b/addons/sequencer/modules/ActivateTriggers/CfgVehicles.hpp
@@ -1,0 +1,18 @@
+class ZT_Module_ActivateTriggers  : BaseSequenceModule {
+	displayName = "Activate Triggers";
+	scope = 2;
+	function = "";
+	ZT_executionFunction = "ZT_Sequencer_fnc_ActivateTriggers";
+	functionPriority = 1;
+	isGlobal = 1;
+	isTriggerActivated = 1;
+	isDisposable = 0;
+	curatorCanAttach = 1;
+	functionContext = "spawn";
+
+	class ModuleDescription : ModuleDescription {
+		description[] = {
+			"Activates all synced triggers. Used for triggering vanilla modules"
+		};
+	};
+};

--- a/addons/sequencer/modules/ActivateTriggers/functions/fn_ActivateTriggers.sqf
+++ b/addons/sequencer/modules/ActivateTriggers/functions/fn_ActivateTriggers.sqf
@@ -1,0 +1,11 @@
+params [
+	["_logic", objNull, [objNull]],		// Argument 0 is module logic
+	["_units", [], [[]]],				// Argument 1 is a list of affected units (affected by value selected in the 'class Units' argument))
+	["_activated", true, [true]]		// True when the module was activated, false when it is deactivated (i.e., synced triggers are no longer active)
+];
+
+// If module is deactivated, just exit
+if (!_activated) exitWith {};
+
+_triggers = [_logic] call ZT_Sequencer_fnc_Global_getSyncedTriggers;
+[_triggers] call ZT_Sequencer_fnc_Global_activateTriggers;

--- a/addons/sequencer/modules/AwaitTriggers/CfgFunctions.hpp
+++ b/addons/sequencer/modules/AwaitTriggers/CfgFunctions.hpp
@@ -1,4 +1,4 @@
 class AwaitTriggers {
 	file = "z\ZT\Sequencer\modules\AwaitTriggers\functions";
-	class AwaitTriggers {};
+	class awaitTriggers {};
 };

--- a/addons/sequencer/modules/AwaitTriggers/CfgFunctions.hpp
+++ b/addons/sequencer/modules/AwaitTriggers/CfgFunctions.hpp
@@ -1,0 +1,4 @@
+class AwaitTriggers {
+	file = "z\ZT\Sequencer\modules\AwaitTriggers\functions";
+	class AwaitTriggers {};
+};

--- a/addons/sequencer/modules/AwaitTriggers/CfgVehicles.hpp
+++ b/addons/sequencer/modules/AwaitTriggers/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class ZT_Module_AwaitTriggers  : BaseSequenceModule {
 	displayName = "Await Triggers";
 	scope = 2;
 	function = "";
-	ZT_executionFunction = "ZT_Sequencer_fnc_AwaitTriggers";
+	ZT_executionFunction = "ZT_Sequencer_fnc_awaitTriggers";
 	functionPriority = 1;
 	isGlobal = 1;
 	isTriggerActivated = 1;

--- a/addons/sequencer/modules/AwaitTriggers/CfgVehicles.hpp
+++ b/addons/sequencer/modules/AwaitTriggers/CfgVehicles.hpp
@@ -1,0 +1,18 @@
+class ZT_Module_AwaitTriggers  : BaseSequenceModule {
+	displayName = "Await Triggers";
+	scope = 2;
+	function = "";
+	ZT_executionFunction = "ZT_Sequencer_fnc_AwaitTriggers";
+	functionPriority = 1;
+	isGlobal = 1;
+	isTriggerActivated = 1;
+	isDisposable = 0;
+	curatorCanAttach = 1;
+	functionContext = "spawn";
+
+	class ModuleDescription : ModuleDescription {
+		description[] = {
+			"Waits for all synced triggers to be activated before continuing"
+		};
+	};
+};

--- a/addons/sequencer/modules/AwaitTriggers/functions/fn_AwaitTriggers.sqf
+++ b/addons/sequencer/modules/AwaitTriggers/functions/fn_AwaitTriggers.sqf
@@ -1,0 +1,11 @@
+params [
+	["_logic", objNull, [objNull]],		// Argument 0 is module logic
+	["_units", [], [[]]],				// Argument 1 is a list of affected units (affected by value selected in the 'class Units' argument))
+	["_activated", true, [true]]		// True when the module was activated, false when it is deactivated (i.e., synced triggers are no longer active)
+];
+
+// If module is deactivated, just exit
+if (!_activated) exitWith {};
+
+_triggers = [_logic] call ZT_Sequencer_fnc_Global_getSyncedTriggers;
+[_triggers, 0.2] call ZT_Sequencer_fnc_Global_waitUntilTriggers;


### PR DESCRIPTION
Added basic modules that deal with incoming and outgoing triggers.

- Await Triggers: Waits for all triggers to be activated before resuming sequence.
- Activate Triggers: Overrides the condition field of all synced triggers and sets it to "true", causing the trigger to be activated.