### PR TITLE
hemtt: added hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # HEMTT
 .hemttout/
+releases/*
 hemtt.exe
 
 # HEMTT Mission

--- a/.hemtt/hooks/post_release/01_rename_zip.rhai
+++ b/.hemtt/hooks/post_release/01_rename_zip.rhai
@@ -1,0 +1,9 @@
+let releases = HEMTT_RFS.join("releases");
+
+let src = releases.join(HEMTT.project().prefix() + "-" + HEMTT.project().version().to_string() + ".zip");
+let dst = releases.join(HEMTT.project().name().to_lower() + "_" + HEMTT.project().version().to_string_short() + ".zip");
+
+print("Moving zip to " + dst);
+if !src.move(dst) {
+    fatal("Failed to move " + src + " to " + dst);
+}

--- a/.hemtt/hooks/pre_build/01_set_version.rhai
+++ b/.hemtt/hooks/pre_build/01_set_version.rhai
@@ -1,0 +1,4 @@
+let modcpp = HEMTT_VFS.join("mod.cpp").open_file().read();
+modcpp.replace("0.0.0", HEMTT.project().version().to_string_short());
+HEMTT_VFS.join("mod.cpp").create_file().write(modcpp);
+print("mod.cpp version set");

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -8,10 +8,9 @@ include = [
     "zt_logo.paa",
 ]
 
-
 [version]
 major = 0
-minor = 0
+minor = 1
 patch = 0
 build = 0
 

--- a/mod.cpp
+++ b/mod.cpp
@@ -1,8 +1,8 @@
-name = "ZeusTools";
+name = "ZeusTools 0.0.0";
 picture = "zt_logo.paa";
 logo = "zt_logo.paa";
 logoOver = "zt_logo.paa";
-tooltip = "ZeusTools";
+tooltip = "ZeusTools 0.0.0";
 tooltipOwned = "ZeusTools Owned";
 overview = "WIP: give this a good description";
 author = "WSV Team";


### PR DESCRIPTION
Normal build will replace the version number with the correct one (obtained from .hemtt/project.toml)

Release build will also rename the zip file accordingly 